### PR TITLE
Feat/add link to receipt preview

### DIFF
--- a/wc-upload-reciept.php
+++ b/wc-upload-reciept.php
@@ -752,7 +752,10 @@ if (!class_exists("peproDev_UploadReceiptWC")) {
           $src = $src_org ? $src_org[0] : $this->defaultImg;
         }
         if ($src_org) {
-          echo "<img src='$src' class='receipt-preview $status' alt='$status_text' title='$status_text' />";
+          $full_url = wp_get_attachment_url($attachment_id);
+          echo "<a href='" . esc_url($full_url) . "' target='_blank'>
+                  <img src='" . esc_url($src) . "' class='receipt-preview $status' alt='" . esc_attr($status_text) . "' title='" . esc_attr($status_text) . "' />
+                </a>";
         } else {
           echo "<span style='box-shadow: 0 0 0 3px #009fff;text-align: center;padding: 0.5rem;'>" . __("Awaiting Upload", $this->td) . "</span>";
         }

--- a/wc-upload-reciept.php
+++ b/wc-upload-reciept.php
@@ -51,12 +51,11 @@ if (!class_exists("peproDev_UploadReceiptWC")) {
     private $use_secure_link;
     private $defaultImg;
     public function __construct() {
-      load_plugin_textdomain("receipt-upload", false, dirname(plugin_basename(__FILE__)) . "/languages/");
       $this->plugin_dir                       = plugin_dir_path(__FILE__);
       $this->assets_url                       = plugins_url("/assets/", __FILE__);
       $this->url                              = admin_url("admin.php?page=wc-settings&tab=checkout&section=upload_receipt");
-      $this->title                            = __("WooCommerce Upload Receipt", $this->td);
-      $this->title_w                          = sprintf(__("%2\$s ver. %1\$s", $this->td), $this->version, $this->title);
+      $this->title                            = 'WooCommerce Upload Receipt';
+      $this->title_w                          = sprintf('%2$s ver. %1$s', $this->version, $this->title);
       $this->folder_name                      = apply_filters("pepro_upload_receipt_folder_name", "receipt_upload");
       $this->status_order_placed              = get_option("peprobacsru_auto_change_status", "none");
       $this->status_receipt_awaiting_upload   = get_option("peprobacsru_status_on_receipt_awaiting_upload", "none");
@@ -1169,6 +1168,11 @@ if (!class_exists("peproDev_UploadReceiptWC")) {
    * @since   1.0.0
    * @license https://pepro.dev/license Pepro.dev License
    */
+  add_action('init', 'load_receipt_upload_textdomain');
+    function load_receipt_upload_textdomain() {
+        load_plugin_textdomain("receipt-upload", false, dirname(plugin_basename(__FILE__)) . "/languages/");
+    }
+
   add_action("plugins_loaded", function () {
     global $Pepro_Upload_Receipt;
     $Pepro_Upload_Receipt = new peproDev_UploadReceiptWC;


### PR DESCRIPTION
This PR improves the user experience by wrapping the receipt preview image with a clickable link in the WooCommerce Orders table, allowing administrators to open the full-size receipt in a new tab without needing to enter the order details.

This provides quicker access to the original uploaded file for viewing or downloading purposes, streamlining the review and approval workflow.