### PR TITLE
fix: ensure receipt attachment meta is saved before email notification

### DIFF
--- a/wc-upload-reciept.php
+++ b/wc-upload-reciept.php
@@ -1071,7 +1071,6 @@ if (!class_exists("peproDev_UploadReceiptWC")) {
             remove_filter("upload_dir", array($this, "change_receipt_upload_dir"));
             $datetime = current_time("Y-m-d H:i:s");
             if (!is_wp_error($attachment_id) && is_numeric($attachment_id)) {
-              do_action("woocommerce_receipt_uploaded_notification", $postOrder);
               $order->update_meta_data("receipt_uploaded_attachment_id", $attachment_id);
               $order->update_meta_data("receipt_upload_date_uploaded", $datetime);
               $order->update_meta_data("receipt_upload_status", "pending");
@@ -1084,6 +1083,7 @@ if (!class_exists("peproDev_UploadReceiptWC")) {
               $url = wp_get_attachment_image_url($attachment_id, [50, 50]);
               $order->add_order_note("<strong>{$this->title}</strong><br>" . sprintf(__("Customer uploaded payment receipt image. %s", $this->td), "<br><a target='_blank' href='" . wp_get_attachment_url($attachment_id) . "'><img src=\"$url\" style='height: 50px; min-width: 50px; border-radius: 4px; border: 1px solid #eee;' /></a>"));
               $order->save();
+              do_action("woocommerce_receipt_uploaded_notification", $postOrder);
               do_action("peprodev_uploadreceipt_customer_uploaded_receipt", $postOrder, $attachment_id);
               wp_send_json_success(
                 array(


### PR DESCRIPTION
This PR ensures that the uploaded receipt is correctly saved to the order metadata before the woocommerce_receipt_uploaded_notification hook is triggered. Previously, the email was being sent before the receipt_uploaded_attachment_id was persisted, causing the admin email to display the default placeholder image.

What was changed:

Moved the woocommerce_receipt_uploaded_notification hook after the call to $order->save() inside the handel_ajax_req() method.